### PR TITLE
Upgrade forecast

### DIFF
--- a/src/beemeteo/sources/__init__.py
+++ b/src/beemeteo/sources/__init__.py
@@ -74,7 +74,7 @@ class Source:
                                     key_mapping, self.hbase_table_forecasting)
         if not data.empty:
             print("This forecast was already in the database")
-            return
+            return False
         else: 
             forecasted_data = self._collect_forecasting(latitude, longitude, now, tz_in_location)
             forecasted_data = forecasted_data.query("timestamp >= {}".format(now.astimezone(pytz.UTC).timestamp())).\
@@ -83,6 +83,7 @@ class Source:
                         self.config['hbase_weather_data'], [("info", "all")],
                         row_fields=["latitude", "longitude", "forecasting_timestamp", "timestamp"])
             print("{} new rows of forecast had been added to the database".format(forecasted_data.index.size))
+            return True
 
     def get_forecasting_data(self, latitude, longitude, date_from, date_to):
         """

--- a/src/beemeteo/sources/__init__.py
+++ b/src/beemeteo/sources/__init__.py
@@ -63,12 +63,26 @@ class Source:
         tz_in_location = pytz.timezone(tz_find.timezone_at(lat=float(latitude), lng=float(longitude)))
         now = pytz.UTC.localize(datetime.datetime.utcnow()).astimezone(tz_in_location)
         now = now.replace(minute=0, second=0, microsecond=0)
-        forecasted_data = self._collect_forecasting(latitude, longitude, now, tz_in_location)
-        forecasted_data = forecasted_data.query("timestamp >= {}".format(now.astimezone(pytz.UTC).timestamp())).\
-            sort_values(by=["forecasting_timestamp", "timestamp"])
-        save_to_hbase(forecasted_data.to_dict(orient="records"), self.hbase_table_forecasting,
-                      self.config['hbase_weather_data'], [("info", "all")],
-                      row_fields=["latitude", "longitude", "forecasting_timestamp", "timestamp"])
+
+        # verify if the data is already in db
+        key_mapping = {"latitude": 0, "longitude": 1, "ts": 2}
+        date_from_local = _datetime_to_tz(now, tz_in_location)
+        date_to_local = _datetime_to_tz(now+datetime.timedelta(minutes=2), tz_in_location)
+        g_ts_ini_utc = _datetime_dt_to_ts_utc(date_from_local)
+        g_ts_end_utc = _datetime_dt_to_ts_utc(date_to_local)
+        data = self._get_from_hbase(latitude, longitude, g_ts_ini_utc, g_ts_end_utc,
+                                    key_mapping, self.hbase_table_forecasting)
+        if not data.empty:
+            print("This forecast was already in the database")
+            return
+        else: 
+            forecasted_data = self._collect_forecasting(latitude, longitude, now, tz_in_location)
+            forecasted_data = forecasted_data.query("timestamp >= {}".format(now.astimezone(pytz.UTC).timestamp())).\
+                sort_values(by=["forecasting_timestamp", "timestamp"])
+            save_to_hbase(forecasted_data.to_dict(orient="records"), self.hbase_table_forecasting,
+                        self.config['hbase_weather_data'], [("info", "all")],
+                        row_fields=["latitude", "longitude", "forecasting_timestamp", "timestamp"])
+            print("{} new rows of forecast had been added to the database".format(forecasted_data.index.size))
 
     def get_forecasting_data(self, latitude, longitude, date_from, date_to):
         """
@@ -145,7 +159,7 @@ class Source:
                 gaps.append((data['ts2_py'].max().to_pydatetime(), min(date_to_local, now)))
             deltas = data['ts2_py'].diff()[1:]
             gaps_tmp = deltas[deltas > timedelta(hours=1)]
-            for i, _ in gaps_tmp.iteritems():
+            for i, _ in gaps_tmp.items():
                 gap_start = data['ts2_py'][i - 1]
                 gap_end = data['ts2_py'][i]
                 gaps.append((gap_start, gap_end))

--- a/src/beemeteo/utils.py
+++ b/src/beemeteo/utils.py
@@ -48,7 +48,7 @@ def _datetime_dt_to_ts_utc(dt):
                datetime.timedelta(seconds=1))
 
 def _local_to_UTC(date, local_tz):
-    return date.replace(tzinfo=local_tz).astimezone(datetime.timezone.utc)
+    return pytz.utc.normalize(date)
 
 def _UTC_to_local(date, local_tz):
     return pytz.UTC.localize(date).astimezone(local_tz)

--- a/tests/test_appleweather.py
+++ b/tests/test_appleweather.py
@@ -5,13 +5,15 @@ import json
 from beemeteo.sources.appleweather import AppleWeather
 
 
-def test_apple_weather():
+def test_apple_weather_historic():
     source = AppleWeather(json.load(open("config.json")))
+    latitude = 41.540
+    longitude = 2.454
     data = source.get_historical_data(
-        latitude=-30.3183,
-        longitude=131.8894413,
-        date_from=datetime.datetime(2022, 1, 1),
-        date_to=datetime.datetime(2022, 1, 9),
+        latitude=latitude,
+        longitude=longitude,
+        date_from=datetime.datetime(2023, 9, 16),
+        date_to=datetime.datetime(2023, 9, 18),
     )
     expected = pd.read_csv("tests/b2back/darksky.csv")
     columns_to_compare = [
@@ -22,7 +24,17 @@ def test_apple_weather():
         "windGust",
         "windSpeed",
     ]
+    print(data)
+    assert data.equals(expected)
 
-    source.collect_forecasting(41.6100308, 0.6307409)
-    x = source.get_forecasting_data(41.6100308, 0.6307409, datetime.datetime(2022, 1, 1), datetime.datetime(2022, 3, 1))
-    #assert_frame_equal(data[columns_to_compare], expected[columns_to_compare])
+def test_apple_weather_forecast():
+    source = AppleWeather(json.load(open("config.json")))
+    latitude = 41.540
+    longitude = 2.454
+    source.collect_forecasting(latitude, longitude)
+    forecast = source.get_forecasting_data(latitude, longitude,
+                                           date_from = datetime.datetime.now()-datetime.timedelta(days=5), 
+                                           date_to = datetime.datetime.now())
+
+    print(forecast)
+    assert forecast.equals(expected)

--- a/tests/test_meteogalicia.py
+++ b/tests/test_meteogalicia.py
@@ -5,13 +5,26 @@ import json
 from beemeteo.sources.meteogalicia import MeteoGalicia
 
 
-def test_meteogalicia():
+def test_meteogalicia_historic():
     source = MeteoGalicia(json.load(open("config.json")))
     data = source.get_historical_data(
         latitude=41.29,
         longitude=2.19,
-        date_from=datetime.datetime(2020, 12, 25),
-        date_to=datetime.datetime(2021, 1, 12),
+        date_from=datetime.datetime(2023, 9, 16),
+        date_to=datetime.datetime(2023, 9, 18),
     )
     expected = pd.read_csv("tests/b2back/meteogalicia.csv")
+    print(data)
     assert data.equals(expected)
+
+def test_meteogalicia_forecast():
+    source = MeteoGalicia(json.load(open("config.json")))
+    latitude=41.29
+    longitude=2.19
+    expected = pd.read_csv("tests/b2back/meteogalicia.csv")
+    source.collect_forecasting(latitude, longitude)
+    forecast = source.get_forecasting_data(latitude, longitude,
+                                           date_from = datetime.datetime.now()-datetime.timedelta(hours=5), 
+                                           date_to = datetime.datetime.now())
+    print(forecast)
+    assert forecast.equals(expected)


### PR DESCRIPTION
Change of sources:

- In forecast, the DB is checked to see if the data is already saved
- Some output prints are given since it didn't give feedback before. Should we add return values and error handling instead? Errors would be useful for automated services to get forecasts.
- iteritems() is depracated since numpy>1.5.0 the new method is items()

Changes on AppleWheather source:

- The Forecast didn't get forecast but it used to get the current weather. Now it has been changed. Now it asks for the forecast of 3 days, since is what meteogalicia gets. (Should we enter this as a parameter?)
- Some simplifications on how to transform to timestamp are added.

Utils _local_to_UTC (function used in AppleWeather):

- pytz_tz is a little complex. It used to add a 15 min offset, with 'Madrid/Europe' timezone. Now it doesn't.

Test files:

- For both Meteo Galicia and AppleWeather new tests are set. Anyhow, the format doesn't assert, does it matter? If it does some data frame format should be added. 
